### PR TITLE
Update Navigation options for wis2node

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VUE_APP_OAPI=http://localhost:8999/pygeoapi
+VUE_APP_DATA=http://localhost:8999/data/

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -28,7 +28,7 @@
                 |
                 <a
                   target="_window_catalogue"
-                  href="http://localhost:8999/pygeoapi"
+                  :href="oapi_url"
                 >
                   {{ $t("navigation.catalogue") }}
                 </a>
@@ -65,6 +65,7 @@ export default defineComponent({
   },
   data: function () {
     return {
+      oapi_url: process.env.VUE_APP_OAPI,
       data_url: process.env.VUE_APP_DATA,
       documentation: documentation,
       height: 110,

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -34,10 +34,10 @@
                 </a>
                 |
                 <a
-                  target="_window_service_monitor"
-                  href="http://localhost:8999/monitor"
+                  target="_window_data"
+                  :href="data_url"
                 >
-                  {{ $t("navigation.service_monitor") }}
+                  {{ $t("navigation.data") }}
                 </a>
                 |
                 <a target="_window_docs" :href="documentation">
@@ -65,6 +65,7 @@ export default defineComponent({
   },
   data: function () {
     return {
+      data_url: process.env.VUE_APP_DATA,
       documentation: documentation,
       height: 110,
     };

--- a/src/locales/_template.json
+++ b/src/locales/_template.json
@@ -2,9 +2,8 @@
   "language": "",
   "navigation": {
     "homepage": "",
-    "plot": "",
     "catalogue": "",
-    "service_monitor": "",
+    "data": "",
     "documentation": ""
   },
   "footer": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2,9 +2,8 @@
   "language": "English",
   "navigation": {
     "homepage": "Homepage",
-    "plot": "Plot",
     "catalogue": "Catalogue",
-    "service_monitor": "Service Monitor",
+    "data": "Data",
     "documentation": "Documentation"
   },
   "footer": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2,9 +2,8 @@
   "language": "Español",
   "navigation": {
     "homepage": "Página Principal",
-    "plot": "Gráfico",
     "catalogue": "Catálogo",
-    "service_monitor": "Monitor de servicio",
+    "dara": "Datos",
     "documentation": "Documentación"
   },
   "footer": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3,7 +3,7 @@
   "navigation": {
     "homepage": "Página Principal",
     "catalogue": "Catálogo",
-    "dara": "Datos",
+    "data": "Datos",
     "documentation": "Documentación"
   },
   "footer": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2,9 +2,8 @@
   "language": "Français",
   "navigation": {
     "homepage": "Page d'accueil",
-    "plot": "Graphique",
     "catalogue": "Catalogue",
-    "service_monitor": "Moniteur de service",
+    "data": "Données",
     "documentation": "Documentation"
   },
   "footer": {


### PR DESCRIPTION
This PR addresses some necessary changes to wis2node-ui to match the updated structure of [wis2node](https://github.com/wmo-im/wis2node/tree/37c27284c794e103a803eb7af7706c11ccbd17d9). The following changes were made:
- Removed hardcoded navigation references to other components of wis2node in favor of defining in the .env file. 
- Update translations to reflect the new navigation options.